### PR TITLE
Fixed docker logs argument for command mysql:logs

### DIFF
--- a/commands
+++ b/commands
@@ -149,7 +149,7 @@ case "$1" in
   mysql:logs)
     DB_IMAGE=mysql/$APP
     ID=$(docker ps -a | grep "$DB_IMAGE" |  awk '{print $1}')
-    docker logs $ID | tail -n 100
+    docker logs --tail=100 $ID
     ;;
 
   mysql-tests)


### PR DESCRIPTION
I was getting an error like "logs requires one argument". I added the --tail=100 option so you no longer have to pipe to tail. I'm guessing the logs syntax has changed in docker.
